### PR TITLE
Enhance SEO architecture with breadcrumbs and service schema

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -27,8 +27,8 @@ const testimonialRotatorScript = `${base}scripts/testimonial-rotator.js`;
         Dynamics 365 · Power Platform · Azure
       </div>
       <h1 class="font-heading text-4xl font-bold leading-tight tracking-tight text-white sm:text-5xl lg:text-6xl xl:text-7xl" data-reveal data-reveal-delay="80">
-        Dynamics 365 Freelancer &amp; Principal Engineer für<span class="hero-highlight-gradient"> skalierbare Sales-</span>
-        <span class="hero-highlight-underline"> und Service-Plattformen</span>
+        Senior Engineer &amp; Dynamics 365 Architect für<span class="hero-highlight-gradient"> skalierbare Plattformen,</span>
+        <span class="hero-highlight-underline"> die echten Business-Value schaffen</span>
       </h1>
       <p class="max-w-2xl text-lg leading-relaxed text-brand-50/90 sm:text-xl" data-reveal data-reveal-delay="140">
         Ich optimiere Customer Journeys mit Power Platform Engineering, Azure Integrationen, DevOps-Automatisierung und gezielter

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -27,10 +27,12 @@ const testimonialRotatorScript = `${base}scripts/testimonial-rotator.js`;
         Dynamics 365 · Power Platform · Azure
       </div>
       <h1 class="font-heading text-4xl font-bold leading-tight tracking-tight text-white sm:text-5xl lg:text-6xl xl:text-7xl" data-reveal data-reveal-delay="80">
-        Wie verwandelt man <span class="hero-highlight-gradient">chaotische Prozesse</span> in<span class="hero-highlight-underline"> selbstlaufende Systeme?</span>
+        Dynamics 365 Freelancer &amp; Principal Engineer für<span class="hero-highlight-gradient"> skalierbare Sales-</span>
+        <span class="hero-highlight-underline"> und Service-Plattformen</span>
       </h1>
       <p class="max-w-2xl text-lg leading-relaxed text-brand-50/90 sm:text-xl" data-reveal data-reveal-delay="140">
-        Ich kombiniere Power Platform Engineering, Azure Integrationen, DevOps und Test Automation, um komplexe Prozesse in skalierbare und qualitätsgesicherte Anwendungen zu verwandeln.
+        Ich optimiere Customer Journeys mit Power Platform Engineering, Azure Integrationen, DevOps-Automatisierung und gezielter
+        UX-Governance – für höhere Conversion, bessere Rankings und stabile Dynamics 365 Rollouts.
       </p>
       <div class="flex flex-wrap items-center gap-4" data-reveal data-reveal-delay="200">
         <a

--- a/src/components/SeoHead.astro
+++ b/src/components/SeoHead.astro
@@ -1,9 +1,15 @@
 ---
+interface Breadcrumb {
+  name: string;
+  url: string;
+}
+
 interface Props {
   title?: string;
   description?: string;
   ogImage?: string;
   url?: string;
+  breadcrumbs?: Breadcrumb[];
 }
 
 const defaultDescription =
@@ -13,7 +19,8 @@ const {
   title,
   description = defaultDescription,
   ogImage = '/og-image.png',
-  url
+  url,
+  breadcrumbs = []
 } = Astro.props as Props;
 
 const baseTitle = 'Dynamics 365 Freelance · Tim Friedrich';
@@ -25,60 +32,122 @@ const canonicalUrl = url
     : Astro.url.href;
 
 const imageUrl = Astro.site ? new URL(ogImage, Astro.site).toString() : ogImage;
+const siteUrl = Astro.site ? Astro.site.toString() : new URL('/', canonicalUrl).toString();
 
-const _jsonLd = {
+const personId = `${siteUrl}#person`;
+const webSiteId = `${siteUrl}#website`;
+const webPageId = `${canonicalUrl}#webpage`;
+const serviceId = `${siteUrl}#service`;
+
+const jsonLd = {
   '@context': 'https://schema.org',
-  '@type': 'Person',
-  name: 'Tim Friedrich',
-  jobTitle: 'Dynamics 365 Freelancer',
-  description,
-  url: canonicalUrl,
-  image: imageUrl,
-  sameAs: [
-    'https://github.com/tim-freelance',
-    'https://www.linkedin.com/in/tim-friedrich',
-    'https://www.youtube.com/@tim-freelance'
-  ],
-  knowsAbout: [
-    'Dynamics 365 Sales',
-    'Dynamics 365 Customer Service',
-    'Power Platform',
-    'Azure Integration Services',
-    'DevOps',
-    'Event-driven Architecture'
-  ],
   '@graph': [
     {
-      '@type': 'SoftwareDeveloper',
+      '@type': 'Person',
+      '@id': personId,
       name: 'Tim Friedrich',
-      skills: [
-        'C# Plugins',
-        'TypeScript',
-        'Power Automate',
-        'Azure Functions',
-        'Power Apps'
+      jobTitle: 'Dynamics 365 Freelancer',
+      description,
+      url: siteUrl,
+      image: imageUrl,
+      sameAs: [
+        'https://github.com/tim-freelance',
+        'https://www.linkedin.com/in/tim-friedrich',
+        'https://www.youtube.com/@tim-freelance'
       ],
-      worksFor: {
-        '@type': 'Organization',
-        name: 'Tim Friedrich Freelance'
+      knowsAbout: [
+        'Dynamics 365 Sales',
+        'Dynamics 365 Customer Service',
+        'Power Platform',
+        'Azure Integration Services',
+        'DevOps',
+        'Event-driven Architecture'
+      ]
+    },
+    {
+      '@type': 'WebSite',
+      '@id': webSiteId,
+      url: siteUrl,
+      name: baseTitle,
+      inLanguage: 'de-DE',
+      publisher: {
+        '@id': personId
       },
-      url: canonicalUrl
+      potentialAction: {
+        '@type': 'SearchAction',
+        target: `${siteUrl}?s={search_term_string}`,
+        'query-input': 'required name=search_term_string'
+      }
+    },
+    {
+      '@type': 'WebPage',
+      '@id': webPageId,
+      url: canonicalUrl,
+      name: pageTitle,
+      description,
+      isPartOf: {
+        '@id': webSiteId
+      },
+      inLanguage: 'de-DE',
+      primaryImageOfPage: imageUrl,
+      about: {
+        '@id': serviceId
+      }
+    },
+    {
+      '@type': 'ProfessionalService',
+      '@id': serviceId,
+      name: 'Dynamics 365 Beratung & Power Platform Engineering',
+      url: siteUrl,
+      description,
+      provider: {
+        '@id': personId
+      },
+      areaServed: {
+        '@type': 'Country',
+        name: 'Deutschland'
+      },
+      serviceType: [
+        'Dynamics 365 Sales Implementierung',
+        'Dynamics 365 Customer Service Optimierung',
+        'Power Platform Engineering',
+        'Azure Integration & Automatisierung',
+        'DevOps Enablement'
+      ]
     }
   ]
 };
+
+if (breadcrumbs.length > 0) {
+  const breadcrumbItems = breadcrumbs.map((crumb, index) => ({
+    '@type': 'ListItem',
+    position: index + 1,
+    name: crumb.name,
+    item: new URL(crumb.url, siteUrl).toString()
+  }));
+
+  (jsonLd['@graph'] as unknown[]).push({
+    '@type': 'BreadcrumbList',
+    '@id': `${webPageId}#breadcrumb`,
+    itemListElement: breadcrumbItems
+  });
+}
 ---
 
 <title>{pageTitle}</title>
 <meta name="description" content={description} />
+<meta name="robots" content="index,follow" />
+<meta name="author" content="Tim Friedrich" />
 <link rel="canonical" href={canonicalUrl} />
 <meta property="og:type" content="website" />
 <meta property="og:title" content={pageTitle} />
 <meta property="og:description" content={description} />
 <meta property="og:url" content={canonicalUrl} />
 <meta property="og:image" content={imageUrl} />
+<meta property="og:locale" content="de_DE" />
 <meta property="og:site_name" content={baseTitle} />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:title" content={pageTitle} />
 <meta name="twitter:description" content={description} />
 <meta name="twitter:image" content={imageUrl} />
-<script type="application/ld+json">{JSON.stringify(_jsonLd)}</script>
+<script type="application/ld+json">{JSON.stringify(jsonLd)}</script>

--- a/src/components/ServicesGrid.astro
+++ b/src/components/ServicesGrid.astro
@@ -4,6 +4,7 @@ interface ServiceItem {
   description: string;
   cta?: string;
   href?: string;
+  id?: string;
 }
 
 interface Props {
@@ -23,13 +24,24 @@ const { heading = 'Leistungen', subheading, items } = Astro.props as Props;
     </div>
     <div class="grid gap-6 md:grid-cols-2">
       {items.map((service, index) => (
-        <article class="card flex flex-col gap-4 border-surface-200 bg-white/85 transition" data-reveal data-reveal-delay={`${index * 80 + 160}`}>
-          <h3 class="text-2xl font-semibold text-slate-900">{service.title}</h3>
-          <p class="text-base text-slate-600">{service.description}</p>
+        <article
+          class="card flex flex-col gap-4 border-surface-200 bg-white/85 transition"
+          data-reveal
+          data-reveal-delay={`${index * 80 + 160}`}
+          id={service.id}
+          itemscope
+          itemtype="https://schema.org/Service"
+        >
+          <meta itemprop="serviceType" content={service.title} />
+          <meta itemprop="provider" content="Tim Friedrich" />
+          <meta itemprop="areaServed" content="Deutschland" />
+          <h3 class="text-2xl font-semibold text-slate-900" itemprop="name">{service.title}</h3>
+          <p class="text-base text-slate-600" itemprop="description">{service.description}</p>
           {service.href && (
             <a
               href={service.href}
               class="mt-auto inline-flex items-center gap-1 text-sm font-semibold text-brand-500 transition hover:text-brand-400"
+              itemprop="url"
             >
               <span>{service.cta ?? 'Mehr erfahren'}</span>
               <span aria-hidden="true">&rarr;</span>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -4,11 +4,17 @@ import Footer from '../components/Footer.astro';
 import SeoHead from '../components/SeoHead.astro';
 import '../styles/global.css';
 
+interface Breadcrumb {
+  name: string;
+  url: string;
+}
+
 interface Props {
   title?: string;
   description?: string;
   ogImage?: string;
   url?: string;
+  breadcrumbs?: Breadcrumb[];
   showHeader?: boolean;
   showFooter?: boolean;
 }
@@ -18,6 +24,7 @@ const {
   description,
   ogImage,
   url,
+  breadcrumbs = [],
   showHeader = true,
   showFooter = true
 } = Astro.props as Props;
@@ -52,7 +59,13 @@ const csp = [
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta http-equiv="Content-Security-Policy" content={csp} />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
-    <SeoHead title={title} description={description} ogImage={ogImage} url={url} />
+    <SeoHead
+      title={title}
+      description={description}
+      ogImage={ogImage}
+      url={url}
+      breadcrumbs={breadcrumbs}
+    />
     <link rel="icon" type="image/svg+xml" href={`${base}favicon.svg`} />
     <link rel="manifest" href={`${base}manifest.webmanifest`} />
     <link rel="preload" href={`${base}assets/fonts/inter-latin.woff2`} as="font" type="font/woff2" crossorigin />

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -2,7 +2,14 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
-<BaseLayout title="Kontakt" description="Nimm Kontakt zu Tim Friedrich auf – Dynamics 365 Freelancer für Power Platform Engineering, Azure Integrationen & DevOps.">
+<BaseLayout
+  title="Kontakt"
+  description="Nimm Kontakt zu Tim Friedrich auf – Dynamics 365 Freelancer für Power Platform Engineering, Azure Integrationen & DevOps."
+  breadcrumbs={[
+    { name: 'Startseite', url: '/' },
+    { name: 'Kontakt', url: '/contact' }
+  ]}
+>
   <section class="bg-surface-100 py-24">
     <div class="mx-auto max-w-3xl px-6 text-center">
       <h1 class="section-title">Gemeinsam Dynamics 365 beschleunigen</h1>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,25 +11,34 @@ const to = (path: string) => `${base}${path.replace(/^\//, '')}`;
 const projects = (await getCollection('projects')).sort((a, b) => (a.data.featured === b.data.featured ? 0 : a.data.featured ? -1 : 1));
 const heroServices = [
   {
-    title: 'Dynamics 365 Prozessdesign',
+    title: 'Dynamics 365 Prozessdesign & UX-Governance',
     description:
-      'Service- und Vertriebsprozesse in Canvas Apps, Custom Pages und modellgetriebenen Apps übersetzt – inklusive UX, Security und Governance.'
+      'Service- und Vertriebsprozesse in Canvas Apps, Custom Pages und modellgetriebenen Apps übersetzt – inklusive UX, Security und Governance.',
+    href: to('services#prozessdesign'),
+    cta: 'Prozessdesign-Ansatz ansehen'
   },
   {
-    title: 'Power Platform Engineering',
-    description: 'C# Plugins, Power Automate Flows, PCF Controls und Dataverse-Logik, die Fachbereiche sofort produktiver machen.'
+    title: 'Power Platform Engineering & Plugins',
+    description: 'C# Plugins, Power Automate Flows, PCF Controls und Dataverse-Logik, die Fachbereiche sofort produktiver machen.',
+    href: to('services#automation'),
+    cta: 'Automatisierung vertiefen'
   },
   {
-    title: 'Azure Integration & Automation',
-    description: 'Serverless Integrationen mit Azure Functions, Service Bus, Event Grid und DevOps-Pipelines für stabile Datenflüsse.'
+    title: 'Azure Integration & Automatisierung',
+    description: 'Serverless Integrationen mit Azure Functions, Service Bus, Event Grid und DevOps-Pipelines für stabile Datenflüsse.',
+    href: to('services#integration'),
+    cta: 'Integrations-Blueprint prüfen'
   },
   {
     title: 'UI Test Automation & Quality Gates',
-    description: 'Playwright-basierte Test-Frameworks für Business-kritische CRM-Workflows mit robusten Retry-Strategien und Quality Gates für sichere Deployments.'
+    description: 'Playwright-basierte Test-Frameworks für Business-kritische CRM-Workflows mit robusten Retry-Strategien und Quality Gates für sichere Deployments.',
+    href: to('services#quality')
   },
   {
-    title: 'Delivery & Enablement',
-    description: 'SCRUM/Kanban, Pairing, Dokumentation und Training – ich hinterlasse ein Team, das selbstständig releasen kann.'
+    title: 'Delivery, DevOps & Enablement',
+    description: 'SCRUM/Kanban, Pairing, Dokumentation und Training – ich hinterlasse ein Team, das selbstständig releasen kann.',
+    href: to('services#enablement'),
+    cta: 'Enablement-Formate entdecken'
   }
 ];
 
@@ -47,9 +56,108 @@ const valueBullets = [
     description: 'Azure DevOps, Code-Quality-Gates und Monitoring sorgen für planbare Deployments ohne Überraschungen.'
   }
 ];
+
+const faqs = [
+  {
+    question: 'Wie starte ich ein Dynamics 365 Projekt mit dir als Freelancer?',
+    answerHtml:
+      'Wir beginnen mit einem fokussierten Erstgespräch, priorisieren die wichtigsten Dynamics 365 Use Cases und planen einen zweiwöchigen Solution Sprint. Über das <a href="mailto:hello@dynamics-tim.dev" class="text-brand-500 underline decoration-2 decoration-brand-200 hover:text-brand-400">Kontaktformular</a> oder per Mail erhältst du in 48 Stunden eine Roadmap inklusive Aufwandsschätzung.',
+    plainAnswer:
+      'Wir starten mit einem Erstgespräch, priorisieren die wichtigsten Dynamics 365 Use Cases und planen einen zweiwöchigen Solution Sprint. Über das Kontaktformular oder per Mail erhältst du in 48 Stunden eine Roadmap inklusive Aufwandsschätzung.'
+  },
+  {
+    question: 'Welche Ergebnisse liefert dein Dynamics 365 Consulting in den ersten 90 Tagen?',
+    answerHtml:
+      'Innerhalb der ersten drei Monate erhältst du einen produktionsnahen Blueprint mit priorisierter Backlog-Liste, validierten Integrationspfaden und messbaren Quick Wins. Die wichtigsten Prozesse landen in funktionsfähigen Canvas Apps bzw. modellgetriebenen Apps, damit dein Team schnell Feedback geben kann.',
+    plainAnswer:
+      'In den ersten 90 Tagen entsteht ein produktionsnaher Blueprint mit priorisiertem Backlog, validierten Integrationen und Quick Wins in Canvas beziehungsweise modellgetriebenen Apps.'
+  },
+  {
+    question: 'Unterstützt du auch bestehende Dynamics 365 Teams langfristig?',
+    answerHtml: `Ja. Ich coache interne Entwickler:innen, führe gemeinsame Code-Reviews durch und implementiere Quality Gates sowie Automatisierung. Über den <a href="${to('profile')}" class="text-brand-500 underline decoration-2 decoration-brand-200 hover:text-brand-400">Profil-Bereich</a> findest du Referenzen und konkrete Technologien, die ich einbringe.`,
+    plainAnswer:
+      'Ich unterstütze bestehende Dynamics 365 Teams mit Coaching, Code-Reviews, Quality Gates und Automatisierung. Referenzen und Technologien findest du im Profil-Bereich.'
+  }
+];
+
+const cornerstoneLinks = [
+  {
+    title: 'Dynamics 365 Leistungs-Blueprint',
+    description:
+      'Alle Serviceangebote inklusive Canvas Apps, Custom Pages, C# Plugins und Azure Integrationen – gebündelt im Leistungsbereich für schnelle Orientierung.',
+    href: to('services'),
+    cta: 'Zu den Leistungen'
+  },
+  {
+    title: 'Profil, Referenzen & Zertifizierungen',
+    description:
+      'E-E-A-T-Signale auf einen Blick: Projekterfolge, Timeline, Zertifizierungen und Technologie-Stack für Dynamics 365 Delivery.',
+    href: to('profile'),
+    cta: 'Profil ansehen'
+  },
+  {
+    title: 'Kontakt & Discovery Call',
+    description:
+      'Direkter Draht für Priorisierung, Aufwandsschätzung und SEO-optimierte Angebotsunterlagen – inklusive optionaler Pushover-Benachrichtigungen.',
+    href: to('contact'),
+    cta: 'Kontakt aufnehmen'
+  }
+];
+
+const canonicalUrl = Astro.site
+  ? new URL(Astro.url.pathname, Astro.site).toString()
+  : Astro.url.href;
+const siteUrl = Astro.site ? Astro.site.toString() : new URL('/', canonicalUrl).toString();
+const providerId = `${siteUrl}#person`;
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: {
+      '@type': 'Answer',
+      text: faq.plainAnswer
+    }
+  }))
+};
+
+const serviceItemList = {
+  '@context': 'https://schema.org',
+  '@type': 'ItemList',
+  name: 'Dynamics 365 & Power Platform Services',
+  itemListElement: heroServices.map((service, index) => {
+    const serviceUrl = new URL(service.href ?? '/', siteUrl).toString();
+    return {
+      '@type': 'ListItem',
+      position: index + 1,
+      item: {
+        '@type': 'Service',
+        name: service.title,
+        description: service.description,
+        url: serviceUrl,
+        provider: {
+          '@type': 'Person',
+          '@id': providerId
+        },
+        areaServed: {
+          '@type': 'Country',
+          name: 'Deutschland'
+        }
+      }
+    };
+  })
+};
+
+const structuredData = [faqSchema, serviceItemList];
 ---
 
-<BaseLayout title="Startseite" description="Dynamics 365 Freelancer für Service- & Sales-Prozesse: Power Platform Engineering, Azure Integrationen, DevOps & Enablement.">
+<BaseLayout
+  title="Startseite"
+  description="Dynamics 365 Freelancer für Service- & Sales-Prozesse: Power Platform Engineering, Azure Integrationen, DevOps & Enablement."
+  breadcrumbs={[{ name: 'Startseite', url: '/' }]}
+>
   <Hero />
 
   <section class="bg-surface-100 py-20">
@@ -74,6 +182,54 @@ const valueBullets = [
 
   <ProjectCards items={projects.slice(0, 2)} />
 
+  <section class="bg-surface-50 py-20">
+    <div class="mx-auto max-w-6xl px-6">
+      <div class="max-w-3xl space-y-4">
+        <h2 class="section-title" data-reveal data-reveal-delay="0">Cornerstone Content &amp; Conversion-Pfade</h2>
+        <p class="text-lg text-slate-600" data-reveal data-reveal-delay="80">
+          Die wichtigsten SEO-Zielseiten verlinken bewusst aufeinander, damit Nutzer:innen und Suchmaschinen die Schwerpunkte Dynamics 365, Power Platform und Azure sofort erkennen. So bleibt die Linkkraft gebündelt – von der Leistungsbeschreibung bis zum Discovery Call.
+        </p>
+      </div>
+      <div class="mt-10 grid gap-6 md:grid-cols-3" data-reveal data-reveal-delay="160">
+        {cornerstoneLinks.map((item, index) => (
+          <article class="card flex h-full flex-col gap-4" data-reveal data-reveal-delay={`${index * 80 + 220}`} key={item.title}>
+            <h3 class="text-xl font-semibold text-slate-900">{item.title}</h3>
+            <p class="text-base text-slate-600">{item.description}</p>
+            <a
+              href={item.href}
+              class="mt-auto inline-flex items-center gap-1 text-sm font-semibold text-brand-500 transition hover:text-brand-400"
+            >
+              <span>{item.cta}</span>
+              <span aria-hidden="true">&rarr;</span>
+            </a>
+          </article>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <section class="bg-surface-100 py-20" id="faq">
+    <div class="mx-auto max-w-6xl px-6">
+      <h2 class="section-title" data-reveal data-reveal-delay="0">FAQ: Dynamics 365 Zusammenarbeit</h2>
+      <div class="mt-10 space-y-6" data-reveal data-reveal-delay="80">
+        {faqs.map((faq, index) => (
+          <details
+            class="group rounded-2xl border border-surface-200 bg-white/90 p-6 shadow-soft transition"
+            data-reveal
+            data-reveal-delay={`${index * 80 + 160}`}
+          >
+            <summary class="flex cursor-pointer items-center justify-between gap-4 text-left text-lg font-semibold text-slate-900">
+              <span>{faq.question}</span>
+              <span class="text-brand-400 transition group-open:rotate-45" aria-hidden="true">+</span>
+            </summary>
+            <div class="mt-4 text-base text-slate-600" set:html={faq.answerHtml}></div>
+          </details>
+        ))}
+      </div>
+    </div>
+  </section>
+
+
   <section class="bg-gradient-to-br from-brand-900 via-brand-800 to-accent-600 py-24 text-white" data-reveal data-reveal-delay="0">
     <div class="mx-auto max-w-5xl px-6 text-center">
       <h2 class="text-3xl font-bold sm:text-4xl" data-reveal data-reveal-delay="0">Bereit für spürbar schnellere Service- und Vertriebsprozesse?</h2>
@@ -90,5 +246,6 @@ const valueBullets = [
       </div>
     </div>
   </section>
+  <script type="application/ld+json" is:inline>{JSON.stringify(structuredData)}</script>
 </BaseLayout>
 

--- a/src/pages/profile.astro
+++ b/src/pages/profile.astro
@@ -9,7 +9,14 @@ const projects = (await getCollection('projects')).sort((a, b) => (a.data.featur
 const certs = (await getCollection('certs')).sort((a, b) => b.data.issued.localeCompare(a.data.issued));
 ---
 
-<BaseLayout title="Profil" description="Profil von Tim Friedrich: Dynamics 365 Freelancer für Power Platform Engineering, Azure Integrationen & DevOps Enablement.">
+<BaseLayout
+  title="Profil"
+  description="Profil von Tim Friedrich: Dynamics 365 Freelancer für Power Platform Engineering, Azure Integrationen & DevOps Enablement."
+  breadcrumbs={[
+    { name: 'Startseite', url: '/' },
+    { name: 'Profil', url: '/profile' }
+  ]}
+>
   <section class="bg-surface-100 py-20">
     <div class="mx-auto max-w-5xl px-6">
       <h1 class="section-title">Über Tim Friedrich</h1>

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -6,22 +6,32 @@ const services = [
   {
     title: 'Dynamics 365 Prozess- & App-Design',
     description:
-      'Workshops, User Journeys sowie modellgetriebene Apps, Canvas Apps und Custom Pages, die Cases schneller durch den Service-Prozess bringen.'
+      'Workshops, User Journeys sowie modellgetriebene Apps, Canvas Apps und Custom Pages, die Cases schneller durch den Service-Prozess bringen.',
+    id: 'prozessdesign'
   },
   {
     title: 'Power Platform Automation & Plugins',
     description:
-      'C# Plugins, Power Automate Flows, PCF Controls und Dataverse-Logik für saubere Automatisierung und erweiterte Business-Regeln.'
+      'C# Plugins, Power Automate Flows, PCF Controls und Dataverse-Logik für saubere Automatisierung und erweiterte Business-Regeln.',
+    id: 'automation'
+  },
+  {
+    title: 'Azure Integration & Automatisierung',
+    description:
+      'Azure Functions, Service Bus, Logic Apps und Event Driven Architecture verbinden Dynamics 365 mit CRM, ERP und Datenplattformen.',
+    id: 'integration'
   },
   {
     title: 'UI Test Automation & Quality Gates',
     description:
-      'Playwright-basierte Test-Frameworks für Business-kritische CRM-Workflows mit robusten Retry-Strategien und Quality Gates für sichere Deployments.'
+      'Playwright-basierte Test-Frameworks für Business-kritische CRM-Workflows mit robusten Retry-Strategien und Quality Gates für sichere Deployments.',
+    id: 'quality'
   },
   {
     title: 'DevOps, Qualität & Enablement',
     description:
-      'CI/CD, ALM, Code-Quality-Gates und Team-Coaching sorgen für nachhaltige Delivery und dokumentierte Übergaben.'
+      'CI/CD, ALM, Code-Quality-Gates und Team-Coaching sorgen für nachhaltige Delivery und dokumentierte Übergaben.',
+    id: 'enablement'
   }
 ];
 
@@ -39,9 +49,46 @@ const formats = [
     description: 'Health Check für bestehende Lösungen inklusive Code-Reviews, Pairing Sessions und Enablement der internen Entwickler:innen.'
   }
 ];
+
+const canonicalUrl = Astro.site
+  ? new URL(Astro.url.pathname, Astro.site).toString()
+  : Astro.url.href;
+const siteUrl = Astro.site ? Astro.site.toString() : new URL('/', canonicalUrl).toString();
+const providerId = `${siteUrl}#person`;
+
+const serviceListSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'ItemList',
+  name: 'Dynamics 365 Leistungen & Consulting',
+  itemListElement: services.map((service, index) => ({
+    '@type': 'ListItem',
+    position: index + 1,
+    item: {
+      '@type': 'Service',
+      name: service.title,
+      description: service.description,
+      url: new URL(`#${service.id ?? ''}`, canonicalUrl).toString(),
+      provider: {
+        '@type': 'Person',
+        '@id': providerId
+      },
+      areaServed: {
+        '@type': 'Country',
+        name: 'Deutschland'
+      }
+    }
+  }))
+};
 ---
 
-<BaseLayout title="Leistungen" description="Dynamics 365 Leistungen für Prozessdesign, Power Platform Engineering, Azure Integrationen und DevOps Enablement.">
+<BaseLayout
+  title="Leistungen"
+  description="Dynamics 365 Leistungen für Prozessdesign, Power Platform Engineering, Azure Integrationen und DevOps Enablement."
+  breadcrumbs={[
+    { name: 'Startseite', url: '/' },
+    { name: 'Leistungen', url: '/services' }
+  ]}
+>
   <section class="bg-surface-100 py-20">
     <div class="mx-auto max-w-5xl px-6 text-center">
       <h1 class="section-title">Leistungen im Überblick</h1>
@@ -85,6 +132,7 @@ const formats = [
       </a>
     </div>
   </section>
+  <script type="application/ld+json" is:inline>{JSON.stringify(serviceListSchema)}</script>
 </BaseLayout>
 
 


### PR DESCRIPTION
## Summary
- tighten the homepage narrative around Dynamics 365 expertise and add a cornerstone section that channels users toward key conversion pages
- extend the shared layout and head metadata with breadcrumb-aware JSON-LD plus service microdata and item lists for richer SERP coverage
- expose breadcrumbs on core pages and emit dedicated service schema on the services overview for consistent internal linking signals

## Testing
- npm run lint *(fails: TypeError: tseslint.configs.recommended is not iterable)*

------
https://chatgpt.com/codex/tasks/task_e_690a299462648331987a1e20da24c313